### PR TITLE
Adicionadas variaveis de ambiente a documentacao

### DIFF
--- a/scripts/editor-de-servicos.default.config
+++ b/scripts/editor-de-servicos.default.config
@@ -23,3 +23,9 @@ ENDPOINTS_HEALTH_ENABLED=true
 
 ## Desabilita a disponibilização de dados sensíveis no estado de saúde, como do cluster ElasticSearch e espaço em disco.
 ENDPOINTS_HEALTH_SENSITIVE=false
+
+## Altera o repositório onde o Editor de Serviços irá buscar as cartas de Serviços
+EDS_CARTAS_REPOSITORIO=https://github.com/servicosgovbr/portal-de-servicos
+
+## Habilita o carregamento dos Xml's para o cache do editor
+FLAGS_ESQUENTAR_CACHE=true


### PR DESCRIPTION
Alterado o arquivo "editor-de-serviços.default.config" de forma a contemplar as variáveis de ambiente não sua documentação.