### PR TITLE
Remove estrategia para resolver conflitos durante Pull

### DIFF
--- a/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
+++ b/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
@@ -259,11 +259,8 @@ public class RepositorioGit {
         try {
             PullResult result = git.pull()
                     .setRebase(true)
-                    .setStrategy(THEIRS)
                     .setProgressMonitor(new LogstashProgressMonitor(log))
                     .call();
-
-
 
             Marker marker = append("git.state", git.getRepository().getRepositoryState().toString())
                     .and(append("git.branch", git.getRepository().getBranch()))


### PR DESCRIPTION
Quando executamos o código, temos uma `java.lang.ClassCastException`
interno no JGit.

A hierarquia de classes das estratégias para resolver conflitos do JGit
está com um problema quando fazemos a parte de `rebase` durante o
`pull`.

Por estarmos fazendo um rebase, podemos ignorar qualquer estrategia de
merge e considerar que um rebase conflitante irá ser reportado como
error, dado que as mudanças sendo propostas serão aplicadas depois do
que já está presente no repositório central.