### PR TITLE
Renderiza página de erro quando usuário não tem acesso

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+javascript:
+    config_file: .jshintrc

--- a/src/main/javascript/acesso-negado.js
+++ b/src/main/javascript/acesso-negado.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  view: function () {
+    return m('#conteudo', [
+      m('span.cabecalho-cor'),
+      m('#wrapper', [
+        m.component(require('cabecalho/cabecalho'), {
+          metadados: false,
+          logout: true,
+          nomeDaPagina: 'Erro'
+        }),
+        m('#erro.scroll', [
+          m('h2', [
+            'Acesso Negado',
+            m('i.fa.fa-bomb.fa-lg')
+          ]),
+          m('p', 'Você não possui permissão para realizar esse tipo de operação')
+        ])
+      ])
+    ]);
+  }
+};

--- a/src/main/javascript/pagina/orgao/editor.js
+++ b/src/main/javascript/pagina/orgao/editor.js
@@ -10,6 +10,7 @@ var publicarOrgao = require('xml/publicar').publicarOrgao;
 var descartarOrgao = require('xml/descartar').descartarOrgao;
 var despublicar = require('api').despublicar;
 var redirecionarNovaPagina = require('redirecionador');
+var permissoes = require('utils/permissoes');
 
 function ehNovo() {
   return m.route.param('id') === 'novo';
@@ -57,6 +58,10 @@ module.exports = {
   },
 
   view: function (ctrl, args) {
+    if (!permissoes.podeCriarPagina('orgao')) {
+      return m.component(require('acesso-negado'));
+    }
+
     if (!ctrl.pagina()) {
       return m('');
     }

--- a/src/main/javascript/pagina/tematica/editor.js
+++ b/src/main/javascript/pagina/tematica/editor.js
@@ -10,6 +10,7 @@ var publicarPagina = require('xml/publicar').publicarPaginaTematica;
 var descartarPagina = require('xml/descartar').descartarPaginaTematica;
 var despublicar = require('api').despublicar;
 var redirecionarNovaPagina = require('redirecionador');
+var permissoes = require('utils/permissoes');
 
 module.exports = {
   controller: function (args) {
@@ -56,6 +57,10 @@ module.exports = {
   },
 
   view: function (ctrl, args) {
+    if (!permissoes.podeCriarPagina('pagina-tematica')) {
+      return m.component(require('acesso-negado'));
+    }
+
     if (!ctrl.pagina()) {
       return m('');
     }

--- a/src/main/javascript/servico/editor.js
+++ b/src/main/javascript/servico/editor.js
@@ -9,6 +9,7 @@ var despublicarServico = require('api').despublicar;
 var servicoEmEdicao = require('servico/servico-em-edicao');
 var redirecionarNovoServico = require('redirecionador');
 var routeUtils = require('utils/route-utils');
+var permissoes = require('utils/permissoes');
 
 var modificado = m.prop(false);
 
@@ -58,6 +59,10 @@ module.exports = {
   },
 
   view: function (ctrl) {
+    if (!permissoes.podeCriarPagina('servico')) {
+      return m.component(require('acesso-negado'));
+    }
+
     var binding = {
       servico: ctrl.servico,
       novo: routeUtils.ehNovo(),


### PR DESCRIPTION
A página de criar um novo serviço está restriginda para acessos através
de API, mas caso a URL fosse acessada diretamente, a pagina se mantinha
carrengando por causa da falta de respostas.

Agora, caso o usuário não tenha permissão para criar um serviço, uma
página de error será renderizada.

Referencia: #497 

<img width="1394" alt="screen shot 2016-01-07 at 6 15 30 pm" src="https://cloud.githubusercontent.com/assets/109474/12181654/afea089c-b56a-11e5-9886-2a17d5de836d.png">
