### PR TITLE
Sincronia de branches remotos

### DIFF
--- a/src/main/java/br/gov/servicos/editor/conteudo/ListaDeConteudo.java
+++ b/src/main/java/br/gov/servicos/editor/conteudo/ListaDeConteudo.java
@@ -80,6 +80,7 @@ public class ListaDeConteudo {
     }
 
     public Set<Metadados> listar() throws FileNotFoundException {
+        repositorioGit.atualizarMetadados();
         Stream<Metadados> orgaos = listarMetadados(ORGAO);
         Stream<Metadados> paginas = listarMetadados(PAGINA_TEMATICA);
         Stream<Metadados> servicos = listarMetadados(SERVICO);

--- a/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
+++ b/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
@@ -378,12 +378,14 @@ public class RepositorioGit {
             try {
                 marker = marker.and(append("git.branch", git.getRepository().getBranch()));
 
-                List<Ref> branches = git.branchList().call();
+                List<Ref> branches = git.branchList().setListMode(ALL).call();
                 log.info(marker, "git branch list: {} branches", branches.size());
 
                 return branches.stream()
                         .map(Ref::getName)
-                        .map(n -> n.replaceAll(R_HEADS, ""));
+                        .map(n -> n.replaceAll(R_HEADS, ""))
+                        .map(n -> n.replaceAll("refs/remotes/[^/]+/", ""))
+                        .distinct();
 
             } catch (IOException | GitAPIException e) {
                 log.error(marker, "Erro ao listar branches", e);

--- a/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
+++ b/src/main/java/br/gov/servicos/editor/git/RepositorioGit.java
@@ -15,6 +15,7 @@ import org.eclipse.jgit.internal.JGitText;
 import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.FetchResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.TrackingRefUpdate;
 import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
@@ -414,4 +415,13 @@ public class RepositorioGit {
         config.save();
     }
 
+    @SneakyThrows
+    public void atualizarMetadados() {
+        comRepositorioAberto(uncheckedFunction(git -> {
+            log.info("git fetch");
+            return git.fetch()
+                    .setProgressMonitor(new LogstashProgressMonitor(log))
+                    .call();
+        }));
+    }
 }


### PR DESCRIPTION
Esse pull request começa a sincronizar as referencias entre a copia do conteúdo local com o repositório remoto, caso outras instancias tenham criado novos documentos.

Uma coisa que ainda é preciso configurar é como lidar com branches inválidas. Algumas branches no repositório remoto podem ter sido criado de forma inválida e durante a sincronia pode haver problemas processando essas novas branches.

Branches inválidas podem acontecer caso uma edição manual, não utilizando o editor, caso não atenda as regras de negócio esperadas.
## Lista de pontos a serem tratados
- [x] Sincronizar metadados de branches
- [x] Considerar branches remotas quando listamos informações
- [ ] Prover uma forma de lidar com branches inválidas
## Algumas opções para lidar com branches inválidas
### Ignorar erros ao tentar processar branches invalidas

Temos algumas opções para lidar com isso:
- Ao tentar editar o conteúdo invalido, redirecionar para a lista principal
- Ao tentar editar o conteúdo invalido, redirecionar para uma página de erro genérica
- Ao tentar editar o conteúdo invalido, redirecionar para uma página de erro mais especifica
### Manter uma lista de branches inválidas no processo

Assim que identificarmos uma branch em estado inválido, nos incluímos em uma lista no processo do backend e filtramos ela da UI.
### Remover branch inválida do remoto automaticamente

Assim que identificarmos uma branch em estado inválido, nos excluímos a branch local e remoto automaticamente. Acredito que essa opção não é a melhor para a experiência do usuário por não dar feedback.

---

Acredito que a melhor experiência de usuário seria ignorar o erro de processamento da branch durante a importação inicial. Quando alguém tentar editar o conteúdo que se encontra em uma branch inválida, uma página de erro mais especifica aparece.

Nesta página, deveríamos prover uma forma do usuário do editor resolver a situação, como um botão de remover conteúdo invalido, que removeria isso localmente e remotamente. 

Essa mudança requer um trabalho com um escopo bem maior, principalmente por necessitar mudanças de UX.

Pode também haver um impacto no tempo de resposta do editor, por estarmos sincronizando em todos os acessos a página principal. Caso o impacto medido aumente de forma considerável, precisamos discutir uma outra estratégia de sincronia.
