### PR TITLE
Muda a fonte do endereço para verificar permissões

### DIFF
--- a/src/main/javascript/utils/permissoes.js
+++ b/src/main/javascript/utils/permissoes.js
@@ -1,4 +1,4 @@
-/*global loggedUser, location*/
+/*global loggedUser*/
 'use strict';
 
 function retornaPermissoes() {
@@ -34,15 +34,15 @@ function possuiPermissaoOrgaoEspecifico(permissao, orgaoIdUsuario, orgaoIdPagina
 }
 
 function estaNaPaginaServico() {
-  return location.pathname.indexOf('editar/servico') > -1;
+  return m.route().indexOf('editar/servico') > -1;
 }
 
 function estaNaPaginaOrgao() {
-  return location.pathname.indexOf('editar/orgao') > -1;
+  return m.route().indexOf('editar/orgao') > -1;
 }
 
 function estaNaPaginaTematica() {
-  return location.pathname.indexOf('editar/pagina-tematica') > -1;
+  return m.route().indexOf('editar/pagina-tematica') > -1;
 }
 
 function possuiPermissaoPaginaServico(permissao) {


### PR DESCRIPTION
Algumas verificações de permissões levam em consideração qual página
estamos visualizando. Extraímos essa informação da URL.

Alguns botões, como o Visualizar, utilizam o roteamento interno do
Mithril, que so altera a URL depois que toa a nova view já foi
processada.
Isso estava causando que o código de autorização recebesse a informação
incorreta e reportasse que o usuário não possui permissão.

Esse commit muda a fonte da informação da URL, e ao invés de usar a
variável global do navegador, utiliza a função do Mithril que sabe sobre
o roteamento.