### PR TITLE
Sobrescreve o repositório de cartas de serviço para dev.

### DIFF
--- a/scripts/snap-deploy-dev
+++ b/scripts/snap-deploy-dev
@@ -11,6 +11,8 @@ set -o pipefail
 cd '/root/docker'
 git pull --rebase
 
+export EDS_CARTAS_REPOSITORIO='git@github.com:servicosgovbr/cartas-de-testes.git'
+
 docker-compose stop editor1 editor2
 docker-compose kill editor1 editor2
 docker-compose rm -f editor1 editor2


### PR DESCRIPTION
Esse commit sobreescreve qual repositório está sendo utilizado no
ambiente de dev.

Pode ser integrado depois que o servicosgovbr/docker#8 estiver no branch
master.