### PR TITLE
Define um fallback para o endereço do repositorio de cartas

### DIFF
--- a/scripts/editor-de-servicos.default.config
+++ b/scripts/editor-de-servicos.default.config
@@ -13,7 +13,11 @@ FLAGS_GIT_PUSH=false
 FLAGS_ESQUENTAR_CACHE=true
 
 ## Define a URL para o repositório onde o sistema irá buscar as cartas de serviços
-EDS_CARTAS_REPOSITORIO=https://github.com/servicosgovbr/cartas-de-servico.git
+EDS_CARTAS_REPOSITORIO=git@github.com:servicosgovbr/editor-de-servicos.git
+
+## Define a URL para o repositório onde o sistema irá buscar as cartas de serviços
+## caso as váriaveis de ambiente sobrescreva EDS_CARTAS_REPOSITORIO e esteja em branco
+FALLBACK_EDS_CARTAS_REPOSITORIO=git@github.com:servicosgovbr/editor-de-servicos.git
 
 ## Desabilita as URLs de informação e estado do sistema disponibilizadas pelo Spring-Boot.
 ENDPOINTS_ENABLED=false

--- a/src/main/java/br/gov/servicos/editor/git/RepositorioConfig.java
+++ b/src/main/java/br/gov/servicos/editor/git/RepositorioConfig.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 
 import static java.nio.file.Files.createTempDirectory;
 import static lombok.AccessLevel.PUBLIC;
+import static org.springframework.util.StringUtils.isEmpty;
 
 @Component
 @FieldDefaults(level = PUBLIC, makeFinal = true)
@@ -25,18 +26,22 @@ public class RepositorioConfig {
 
     @Autowired
     public RepositorioConfig(@Value("${eds.cartas.repositorio}") String urlRepositorioCartas,
+                             @Value("${fallback.eds.cartas.repositorio}") String urlFallbackRepositorioCartas,
                              @Value("${flags.importar}") boolean deveImportar,
                              @Value("${flags.git.push}") boolean fazerPush) throws IOException {
-        this(urlRepositorioCartas, deveImportar, fazerPush, createTempDirectory("editor-de-servicos").toFile());
+        this(urlRepositorioCartas, urlFallbackRepositorioCartas, deveImportar, fazerPush, createTempDirectory("editor-de-servicos").toFile());
     }
 
     @SneakyThrows
     public RepositorioConfig(String urlRepositorioCartas,
+                             String urlFallbackRepositorioCartas,
                              boolean deveImportar,
                              boolean fazerPush,
                              File localRepositorioDeCartas) {
 
-        this.urlRepositorioCartas = urlRepositorioCartas;
+        String url = isEmpty(urlRepositorioCartas) ? urlFallbackRepositorioCartas : urlRepositorioCartas;
+
+        this.urlRepositorioCartas = url;
         this.deveImportar = deveImportar;
         this.fazerPush = fazerPush;
         this.localRepositorioDeCartas = localRepositorioDeCartas;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -40,7 +40,12 @@ eds:
   token:
     desabilitarUsuario: false
   cartas:
-    repositorio: "https://github.com/servicosgovbr/cartas-de-teste.git"
+    repositorio: "git@github.com:servicosgovbr/cartas-de-teste.git"
+
+fallback:
+  eds:
+    cartas:
+      repositorio: "git@github.com:servicosgovbr/cartas-de-servico.git"
 
 ---
 

--- a/src/test/java/br/gov/servicos/editor/conteudo/RepositorioGitTest.java
+++ b/src/test/java/br/gov/servicos/editor/conteudo/RepositorioGitTest.java
@@ -73,8 +73,8 @@ public class RepositorioGitTest {
         System.out.println("test clone1" + clone1);
         System.out.println("test clone2" + clone2);
 
-        this.repo1 = new RepositorioGit(new RepositorioConfig("", false, true, clone1));
-        this.repo2 = new RepositorioGit(new RepositorioConfig("", false, true, clone2));
+        this.repo1 = new RepositorioGit(new RepositorioConfig("", "", false, true, clone1));
+        this.repo2 = new RepositorioGit(new RepositorioConfig("", "", false, true, clone2));
     }
 
     @Test

--- a/src/test/java/br/gov/servicos/editor/fixtures/RepositorioConfigParaTeste.java
+++ b/src/test/java/br/gov/servicos/editor/fixtures/RepositorioConfigParaTeste.java
@@ -53,6 +53,7 @@ public class RepositorioConfigParaTeste {
     @Bean
     public RepositorioConfig testConfig() {
         return new RepositorioConfig(origin.toString(),
+                "",
                 true,
                 true,
                 localCloneRepositorio.toFile());


### PR DESCRIPTION
A opção de qual repositório será a fonte de informações para o editor é
configurável através de variaveis de ambiente e arquivos de
configuração.

Uma situação que impediria o funcionamento do editor é caso a váriavel
de ambiente que é utilizada para apontar para o repositório de cartas
esteja definida, mas possua um valor em branco.

Isso pode acontecer quando exportamos uma váriavel shell da seguinte
maneira antes de subir a aplicação.

```bash
export EDS_CARTAS_REPOSITORIO=''
```

Para evitar que a aplicação quebre ao subir com um valor em branco, esse
commit introduz uma váriavel extra, para caso não exista um valor, nós
utilizaremos o repositório oficial através do ssh, para que mudanças
sejam enviadas utilizando a chave de acesso.